### PR TITLE
ci: fix poetry export

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install poetry and flake8
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 poetry
+          python -m pip install flake8 poetry poetry-plugin-export
 
       - name: Install project dependencies
         run: |


### PR DESCRIPTION
poetry-plugin-export has been removed as a dependency of poetry in version 2.0 and above.