### PR TITLE
remove mypy workaround for Python 3.12-alpha

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,9 +45,6 @@ jobs:
           pylint .
 
       - name: Lint with mypy
-        # Python 3.12 is currently unsupported
-        # see https://github.com/python/mypy/issues/15277
-        if: ${{ matrix.python-version != '3.12.0-alpha - 3.12' }}
         run: |
           mypy .
 


### PR DESCRIPTION
This reverts commit 59293f2bc348bc23532cce6a22bcb964b9194f48.